### PR TITLE
Feature/remove path card logic and test

### DIFF
--- a/apps/backend/src/action/command/rockfall.command.ts
+++ b/apps/backend/src/action/command/rockfall.command.ts
@@ -1,13 +1,16 @@
 import z from "zod";
+import type { Placement } from "~/models/placement";
+import { PlacementSchema } from "~/models/placement";
 
 export const RockfallCommandSchema = z.object({
   type: z.literal("use action card (rockfall)"),
+  data: PlacementSchema,
 });
 
 export type RockfallCommand = Readonly<z.infer<typeof RockfallCommandSchema>>;
 
-export function RockfallCommand(): RockfallCommand {
-  return { type: "use action card (rockfall)" };
+export function RockfallCommand(data: Placement): RockfallCommand {
+  return { type: "use action card (rockfall)", data };
 }
 
 export function isRockfallCommand(

--- a/apps/backend/src/action/command/rockfall.command.ts
+++ b/apps/backend/src/action/command/rockfall.command.ts
@@ -1,15 +1,21 @@
 import z from "zod";
-import type { Placement } from "~/models/placement";
-import { PlacementSchema } from "~/models/placement";
+import { ActionCard } from "~/models/card";
+
+export const RockfallCardSchema = z.object({
+  card: z.literal(ActionCard.ROCKFALL),
+  position: z.tuple([z.number(), z.number()]),
+});
+
+export type RockfallCard = z.infer<typeof RockfallCardSchema>;
 
 export const RockfallCommandSchema = z.object({
   type: z.literal("use action card (rockfall)"),
-  data: PlacementSchema,
+  data: RockfallCardSchema,
 });
 
 export type RockfallCommand = Readonly<z.infer<typeof RockfallCommandSchema>>;
 
-export function RockfallCommand(data: Placement): RockfallCommand {
+export function RockfallCommand(data: RockfallCard): RockfallCommand {
   return { type: "use action card (rockfall)", data };
 }
 

--- a/apps/backend/src/action/event/path-card-has-been-removed.event.ts
+++ b/apps/backend/src/action/event/path-card-has-been-removed.event.ts
@@ -1,9 +1,9 @@
 import z from "zod";
-import { Placement, PlacementSchema } from "~/models/placement";
+import { RockfallCard, RockfallCardSchema } from "../command";
 
 export const PathCardHasBeenRemovedEventSchema = z.object({
   type: z.literal("path card has been removed"),
-  data: PlacementSchema,
+  data: RockfallCardSchema,
 });
 
 export type PathCardHasBeenRemovedEvent = Readonly<
@@ -17,7 +17,7 @@ export function isPathCardHasBeenRemovedEvent(
 }
 
 export function PathCardHasBeenRemovedEvent(
-  data: Placement
+  data: RockfallCard
 ): PathCardHasBeenRemovedEvent {
   return { type: "path card has been removed", data };
 }

--- a/apps/backend/src/action/logic/remove-path-card.test.ts
+++ b/apps/backend/src/action/logic/remove-path-card.test.ts
@@ -1,3 +1,15 @@
+import type { EventSource } from "~/models/event";
+import type { BoardEvent } from "~/board/event";
+
 describe("remove path card", () => {
-  test.todo("todo");
+  let source: EventSource<BoardEvent>;
+
+  test.todo(`
+    given:
+      
+    when:
+      
+    then:
+      
+  `);
 });

--- a/apps/backend/src/action/logic/remove-path-card.test.ts
+++ b/apps/backend/src/action/logic/remove-path-card.test.ts
@@ -1,15 +1,210 @@
 import type { EventSource } from "~/models/event";
-import type { BoardCardEvent } from "./remove-path-card";
+import { PathCardHasBeenPlacedEvent } from "~/board/event";
+import { ActionCard, PathCard } from "~/models/card";
+import { never } from "~/utils";
+import removePathCard, { BoardCardEvent } from "./remove-path-card";
+import { PathCardHasBeenRemovedEvent } from "../event";
+import { RockfallCommand } from "../command";
 
 describe("remove path card", () => {
   let source: EventSource<BoardCardEvent>;
 
-  test.todo(`
+  beforeEach(() => {
+    let store: unknown[] = [];
+    const append = jest.fn().mockImplementation((...args: unknown[]) => {
+      store = store.concat(...args);
+      return Promise.resolve(args);
+    });
+    const read = jest.fn().mockImplementation(() => {
+      return Promise.resolve(store);
+    });
+    source = { append, read, on: jest.fn(), off: jest.fn() };
+  });
+
+  test(`
     given:
-      
+      a board with:
+        - start card at position (0, 0)
     when:
-      
+      remove
+        - start card at position (0, 0)
     then:
-      
-  `);
+      - should return error
+        - the start card cannot be removed.
+      - event source should not includes
+        - path card has been removed
+  `, () => {
+    source
+      .append(
+        PathCardHasBeenPlacedEvent({
+          card: PathCard.START,
+          position: [0, 0],
+        })
+      )
+      .then(() =>
+        removePathCard(
+          source,
+          RockfallCommand({
+            card: ActionCard.ROCKFALL,
+            position: [0, 0],
+          })
+        )
+      )
+      .then((result) => {
+        result.match(never, (error) =>
+          expect(error).toStrictEqual(
+            Error(`the path card ${PathCard.START} cannot be removed`)
+          )
+        );
+      })
+      .then(() =>
+        source.read().then((events) =>
+          expect(events).toStrictEqual([
+            PathCardHasBeenPlacedEvent({
+              card: PathCard.START,
+              position: [0, 0],
+            }),
+          ])
+        )
+      );
+  });
+
+  test(`
+    given:
+      a board with:
+        - goal card [Gold] at position (8, 0)
+    when:
+      remove
+        - goal card [Gold] at position (8, 0)
+    then:
+      - should return error
+        - the gold card [Gold] cannot be removed.
+      - event source should not includes
+        - path card has been removed
+  `, () => {
+    source
+      .append(
+        PathCardHasBeenPlacedEvent({
+          card: PathCard.GOAL_GOLD,
+          position: [8, 0],
+        })
+      )
+      .then(() =>
+        removePathCard(
+          source,
+          RockfallCommand({
+            card: ActionCard.ROCKFALL,
+            position: [8, 0],
+          })
+        )
+      )
+      .then((result) => {
+        result.match(never, (error) =>
+          expect(error).toStrictEqual(
+            Error(`the path card ${PathCard.GOAL_GOLD} cannot be removed`)
+          )
+        );
+      })
+      .then(() =>
+        source.read().then((events) =>
+          expect(events).toStrictEqual([
+            PathCardHasBeenPlacedEvent({
+              card: PathCard.GOAL_GOLD,
+              position: [8, 0],
+            }),
+          ])
+        )
+      );
+  });
+
+  test(`
+    given:
+      a board with:
+        - path card [connected cross] at position (1, 0)
+    when:
+      remove
+        - path card [connected cross] at position (1, 0)
+    then:
+      - should return event
+        - path card has been removed event.
+      - event source should includes
+        - path card has been removed
+  `, () => {
+    source
+      .append(
+        PathCardHasBeenPlacedEvent({
+          card: PathCard.CONNECTED_CROSS,
+          position: [1, 0],
+        })
+      )
+      .then(() =>
+        removePathCard(
+          source,
+          RockfallCommand({
+            card: ActionCard.ROCKFALL,
+            position: [1, 0],
+          })
+        )
+      )
+      .then((result) => {
+        result.match(
+          (result) =>
+            expect(result).toStrictEqual(
+              PathCardHasBeenRemovedEvent({
+                card: ActionCard.ROCKFALL,
+                position: [1, 0],
+              })
+            ),
+          never
+        );
+      })
+      .then(() =>
+        source.read().then((events) =>
+          expect(events).toStrictEqual([
+            PathCardHasBeenPlacedEvent({
+              card: PathCard.CONNECTED_CROSS,
+              position: [1, 0],
+            }),
+            PathCardHasBeenRemovedEvent({
+              card: ActionCard.ROCKFALL,
+              position: [1, 0],
+            }),
+          ])
+        )
+      );
+  });
+
+  test(`
+    given:
+      an empty board
+    when:
+      remove
+        - empty placement at position (1, 0)
+    then:
+      - should return event
+        - empty placement cannot be removed.
+      - event source should not includes
+        - path card has been removed
+  `, () => {
+    Promise.resolve()
+      .then(() =>
+        removePathCard(
+          source,
+          RockfallCommand({
+            card: ActionCard.ROCKFALL,
+            position: [1, 0],
+          })
+        )
+      )
+      .then((result) => {
+        result.match(never, (error) =>
+          expect(error).toStrictEqual(
+            Error("empty placement cannot be removed")
+          )
+        );
+      })
+      .then(() =>
+        source.read().then((events) => expect(events).toStrictEqual([]))
+      );
+  });
 });

--- a/apps/backend/src/action/logic/remove-path-card.test.ts
+++ b/apps/backend/src/action/logic/remove-path-card.test.ts
@@ -1,8 +1,8 @@
 import type { EventSource } from "~/models/event";
-import type { BoardEvent } from "~/board/event";
+import type { BoardCardEvent } from "./remove-path-card";
 
 describe("remove path card", () => {
-  let source: EventSource<BoardEvent>;
+  let source: EventSource<BoardCardEvent>;
 
   test.todo(`
     given:

--- a/apps/backend/src/action/logic/remove-path-card.ts
+++ b/apps/backend/src/action/logic/remove-path-card.ts
@@ -1,14 +1,78 @@
-import { ResultAsync, errAsync } from "neverthrow";
+import { ResultAsync, ok, err } from "neverthrow";
 import { EventSource } from "~/models/event";
 import { RockfallCommand } from "~/action/command";
-import { PathCardHasBeenRemovedEvent, Event } from "~/action/event";
+import { PathCardHasBeenRemovedEvent } from "~/action/event";
+import type { BoardEvent } from "~/board/event";
+import getCurrentPlacements from "~/board/logic/get-current-placements";
+import { Placement } from "~/models/placement";
+import { flow, pipe } from "fp-ts/lib/function";
+import { prop, error, always } from "~/utils";
+import { PathCard } from "~/models/card";
+import * as Vec from "~/models/vec";
+import * as Array from "fp-ts/Array";
+import * as Either from "fp-ts/Either";
+
+const TargetCannotBeRemovedError = error("TargetCannotBeRemovedError");
+const RepositoryWriteError = error("RepositoryWriteError");
+export type RepositoryWriteError = ReturnType<typeof RepositoryWriteError>;
+export type TargetCannotBeRemovedError = ReturnType<
+  typeof TargetCannotBeRemovedError
+>;
+export type RemovePathCardError =
+  | TargetCannotBeRemovedError
+  | RepositoryWriteError;
 
 export interface RemovePathCard {
-  (source: EventSource<Event>, command: RockfallCommand): ResultAsync<
+  (source: EventSource<BoardEvent>, command: RockfallCommand): ResultAsync<
     PathCardHasBeenRemovedEvent,
     Error
   >;
 }
+
+const NonRemovablePathCard = new Set([
+  PathCard.START,
+  PathCard.GOAL_COAL_BOTTOM_LEFT,
+  PathCard.GOAL_COAL_BOTTOM_RIGHT,
+  PathCard.GOAL_GOLD,
+]);
+
+const isRemovablePathCard = Either.fromPredicate<
+  Placement,
+  TargetCannotBeRemovedError
+>(
+  (placement) => !NonRemovablePathCard.has(placement.card),
+  (placement) =>
+    TargetCannotBeRemovedError(
+      `the path card ${placement.card} cannot be removed`
+    )
+);
+
+const findPlacementByPosition =
+  (command: RockfallCommand) => (board: Placement[]) =>
+    Array.findFirst<Placement>(
+      flow(prop("position"), Vec.eq(command.data.position))
+    )(board);
+
+const checkPathCardHasBeenPlaced =
+  (command: RockfallCommand) => (board: Placement[]) =>
+    pipe(
+      board,
+      findPlacementByPosition(command),
+      Either.fromOption(() =>
+        TargetCannotBeRemovedError("empty placement cannot be removed")
+      ),
+      Either.chain(isRemovablePathCard),
+      Either.matchW(err, always(ok(command)))
+    );
+
+const appendEventToEventSource =
+  (source: EventSource<BoardEvent>, command: RockfallCommand) => () =>
+    pipe(PathCardHasBeenRemovedEvent(command.data), (event) =>
+      ResultAsync.fromPromise<PathCardHasBeenRemovedEvent, Error>(
+        Promise.resolve(event),
+        always(RepositoryWriteError("failed to write event to repository"))
+      )
+    );
 
 /**
  * *description*
@@ -17,11 +81,13 @@ export interface RemovePathCard {
  * *param* source - event source
  * *param* command - rockfall command
  */
-export const removePathCard: RemovePathCard = (source, command) => {
+
+export const removePathCard: RemovePathCard = (source, command) =>
   //@todo: read from event source
   //@todo: check path card has been placed
   //@todo: append event to event source
-  return errAsync(new Error("not implemented"));
-};
+  getCurrentPlacements(source)
+    .andThen(checkPathCardHasBeenPlaced(command))
+    .andThen(appendEventToEventSource(source, command));
 
 export default removePathCard;


### PR DESCRIPTION
Would it be possible to include events for removing cards in the BoardEvent type as well, so that getCurrentPlacements can obtain the correct PathCard on the board?

Close: #57 