### PR TITLE
Fix: check connect to neighbor logic

### DIFF
--- a/apps/backend/src/board/logic/check-positions-is-connected.test.ts
+++ b/apps/backend/src/board/logic/check-positions-is-connected.test.ts
@@ -1,0 +1,53 @@
+import { PathCard } from "~/models/card";
+import { never } from "~/utils";
+import { Position } from "./get-available-positions";
+import { getNeighbors, isConnectNeighbor } from "./check-positions-is-connected";
+import { Placement } from "~/models/placement";
+
+describe("check positions is connected", () => {
+  let board: Placement[];
+
+  beforeEach(() => {
+    board = [
+      { position: [0, 0], card: PathCard.START },
+      { position: [0, 1], card: PathCard.CONNECTED_BOTTOM_RIGHT },
+      { position: [1, 1], card: PathCard.CONNECTED_TOP_LEFT_RIGHT },
+      { position: [-1, 0], card: PathCard.DEADEND_TOP_BOTTOM_RIGHT },
+    ];
+  });
+
+  it.each<[Position, Position[]]>([
+    [[1,1], [[1,2], [1,0], [2,1], [0,1]]],
+    [[-1,-1], [[-1,0], [-1,-2], [0,-1], [-2,-1]]],
+  ])(`
+      [getNeighbors]
+      given:
+        position
+      expect:
+        should return positions of its top, right, bottom, left neighbors
+    `, (position: Position, expected: Position[]) => {
+      expect(getNeighbors(position)).toIncludeSameMembers(expected);
+    });
+
+  it.each<[Placement, boolean]>([
+    [{ position: [1, 0], card: PathCard.CONNECTED_BOTTOM_RIGHT }, false],
+    [{ position: [1, 0], card: PathCard.CONNECTED_LEFT_RIGHT }, true],
+    [{ position: [1, 0], card: PathCard.CONNECTED_CROSS }, false],
+    [{ position: [1, 0], card: PathCard.CONNECTED_TOP_LEFT_RIGHT }, false],
+    [{ position: [1, 0], card: PathCard.DEADEND_LEFT }, true],
+    [{ position: [1, 0], card: PathCard.DEADEND_BOTTOM_LEFT }, true],
+    [{ position: [-1, 1], card: PathCard.DEADEND_LEFT }, false],
+    [{ position: [-1, 1], card: PathCard.DEADEND_BOTTOM_LEFT }, true],
+    [{ position: [-1, 1], card: PathCard.DEADEND_BOTTOM_RIGHT }, false],
+    [{ position: [-1, 1], card: PathCard.DEADEND_BOTTOM }, true],
+  ])(`
+      [isConnectNeighbor]
+      preset: board
+      given:
+        a placement %j
+      expect:
+        is placement connected to neighbors on current board: %j
+    `, (y: Placement, expected: boolean) => {
+      expect(isConnectNeighbor(board)(y)).toStrictEqual(expected);
+    });
+});

--- a/apps/backend/src/board/logic/check-positions-is-connected.test.ts
+++ b/apps/backend/src/board/logic/check-positions-is-connected.test.ts
@@ -1,7 +1,9 @@
 import { PathCard } from "~/models/card";
-import { never } from "~/utils";
 import { Position } from "./get-available-positions";
-import { getNeighbors, isConnectNeighbor } from "./check-positions-is-connected";
+import {
+  getNeighbors,
+  isConnectNeighbor,
+} from "./check-positions-is-connected";
 import { Placement } from "~/models/placement";
 
 describe("check positions is connected", () => {
@@ -17,17 +19,36 @@ describe("check positions is connected", () => {
   });
 
   it.each<[Position, Position[]]>([
-    [[1,1], [[1,2], [1,0], [2,1], [0,1]]],
-    [[-1,-1], [[-1,0], [-1,-2], [0,-1], [-2,-1]]],
-  ])(`
+    [
+      [1, 1],
+      [
+        [1, 2],
+        [1, 0],
+        [2, 1],
+        [0, 1],
+      ],
+    ],
+    [
+      [-1, -1],
+      [
+        [-1, 0],
+        [-1, -2],
+        [0, -1],
+        [-2, -1],
+      ],
+    ],
+  ])(
+    `
       [getNeighbors]
       given:
         position
       expect:
         should return positions of its top, right, bottom, left neighbors
-    `, (position: Position, expected: Position[]) => {
+    `,
+    (position: Position, expected: Position[]) => {
       expect(getNeighbors(position)).toIncludeSameMembers(expected);
-    });
+    }
+  );
 
   it.each<[Placement, boolean]>([
     [{ position: [1, 0], card: PathCard.CONNECTED_BOTTOM_RIGHT }, false],
@@ -40,14 +61,17 @@ describe("check positions is connected", () => {
     [{ position: [-1, 1], card: PathCard.DEADEND_BOTTOM_LEFT }, true],
     [{ position: [-1, 1], card: PathCard.DEADEND_BOTTOM_RIGHT }, false],
     [{ position: [-1, 1], card: PathCard.DEADEND_BOTTOM }, true],
-  ])(`
+  ])(
+    `
       [isConnectNeighbor]
       preset: board
       given:
         a placement %j
       expect:
         is placement connected to neighbors on current board: %j
-    `, (y: Placement, expected: boolean) => {
+    `,
+    (y: Placement, expected: boolean) => {
       expect(isConnectNeighbor(board)(y)).toStrictEqual(expected);
-    });
+    }
+  );
 });

--- a/apps/backend/src/board/logic/check-positions-is-connected.test.ts
+++ b/apps/backend/src/board/logic/check-positions-is-connected.test.ts
@@ -40,10 +40,10 @@ describe("check positions is connected", () => {
   ])(
     `
       [getNeighbors]
-      given:
-        position
+      when:
+        input position %j
       expect:
-        should return positions of its top, right, bottom, left neighbors
+        should return positions %j
     `,
     (position: Position, expected: Position[]) => {
       expect(getNeighbors(position)).toIncludeSameMembers(expected);
@@ -64,9 +64,14 @@ describe("check positions is connected", () => {
   ])(
     `
       [isConnectNeighbor]
-      preset: board
       given:
-        a placement %j
+        - a board with:
+          - start card at position (0, 0)
+          - path card connected bottom right at position (0, 1)
+          - path card connected top left right at position (1, 1)
+          - path card deadend top bottom right at position (-1, 0)
+      when:
+        add new placement %j
       expect:
         is placement connected to neighbors on current board: %j
     `,

--- a/apps/backend/src/board/logic/check-positions-is-connected.ts
+++ b/apps/backend/src/board/logic/check-positions-is-connected.ts
@@ -90,13 +90,13 @@ const ifNotConnectNeighbor = Either.fromPredicate<Placement[], AggregateError>(
     )
 );
 
-const getNeighbors = (position: Position) =>
+export const getNeighbors = (position: Position) =>
   available({
     position: position,
     card: PathCard.CONNECTED_CROSS,
   });
 
-const isConnectNeighbor = (board: Placement[]) => (y: Placement) => {
+export const isConnectNeighbor = (board: Placement[]) => (y: Placement) => {
   const neighbors = Vec.Set(getNeighbors(y.position));
   const yPaths = Vec.Set(directions2Vec(PathCardRule[y.card].directions));
   return (
@@ -109,22 +109,22 @@ const isConnectNeighbor = (board: Placement[]) => (y: Placement) => {
         const xPaths = Vec.Set(directions2Vec(PathCardRule[x.card].directions));
         if (Vec.eq(direction, Vec.radianToVec(Direction.LEFT))) {
           return (
-            xPaths.has(Vec.radianToVec(Direction.RIGHT)) &&
+            xPaths.has(Vec.radianToVec(Direction.RIGHT)) ===
             yPaths.has(Vec.radianToVec(Direction.LEFT))
           );
         } else if (Vec.eq(direction, Vec.radianToVec(Direction.TOP))) {
           return (
-            xPaths.has(Vec.radianToVec(Direction.BOTTOM)) &&
+            xPaths.has(Vec.radianToVec(Direction.BOTTOM)) ===
             yPaths.has(Vec.radianToVec(Direction.TOP))
           );
         } else if (Vec.eq(direction, Vec.radianToVec(Direction.RIGHT))) {
           return (
-            xPaths.has(Vec.radianToVec(Direction.LEFT)) &&
+            xPaths.has(Vec.radianToVec(Direction.LEFT)) ===
             yPaths.has(Vec.radianToVec(Direction.RIGHT))
           );
         } else if (Vec.eq(direction, Vec.radianToVec(Direction.BOTTOM))) {
           return (
-            xPaths.has(Vec.radianToVec(Direction.TOP)) &&
+            xPaths.has(Vec.radianToVec(Direction.TOP)) ===
             yPaths.has(Vec.radianToVec(Direction.BOTTOM))
           );
         }

--- a/apps/backend/src/models/vec.ts
+++ b/apps/backend/src/models/vec.ts
@@ -4,7 +4,7 @@ function diff_2(v1: Vec2, v2: Vec2): Vec2 {
   return diff_1(v1)(v2);
 }
 function diff_1(v1: Vec2): (v2: Vec2) => Vec2 {
-  return (v2) => [v1[0] + v2[0], v1[1] + v2[1]];
+  return (v2) => [v1[0] - v2[0], v1[1] - v2[1]];
 }
 export function diff(v1: Vec2): (v2: Vec2) => Vec2;
 export function diff(v1: Vec2, v2: Vec2): Vec2;


### PR DESCRIPTION
- when check connectivity relationships, should use `xnor` instead of `and`
- fix vector diff
- add unit tests
  - test isConnectNeighbor
  - test getNeighbors
  
ref: [jest test.each ](https://jestjs.io/docs/api#testeachtablename-fn-timeout)